### PR TITLE
feat: add PROXY_DOMAIN configuration and update reverse proxy logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Preview Proxy is a simple yet powerful reverse proxy that allows you to route tr
 The proxy can be configured using environment variables:
 
 - `PORT`: Port to listen on (default: 18080)
+- `PROXY_DOMAIN`: Domain to listen on (required)
 - `ORIGIN_PORT`: Port of the origin server (default: 443)
 - `ORIGIN_BASE_DOMAIN`: Base domain for the origin server (required)
 - `ORIGIN_SCHEME`: Scheme for the origin server (default: http)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,10 +19,10 @@ func main() {
 
 	http.Handle("/proxy/healthz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
-	proxy := pkg.NewReverseProxy(cfg.OriginScheme, cfg.OriginBaseDomain, cfg.OriginPort)
+	proxy := pkg.NewReverseProxy(cfg.OriginScheme, cfg.ProxyDomain, cfg.OriginBaseDomain, cfg.OriginPort)
 	http.Handle("/", proxy)
 	listenHost := fmt.Sprintf(":%v", port)
 	slog.Info("Listen on", "host", listenHost)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -8,6 +8,7 @@ var c *Config
 
 type Config struct {
 	Port             int    `envconfig:"PORT" default:"18080"`
+	ProxyDomain      string `envconfig:"PROXY_DOMAIN" default:"localhost"`
 	OriginPort       int    `envconfig:"ORIGIN_PORT" default:"443"`
 	OriginBaseDomain string `envconfig:"ORIGIN_BASE_DOMAIN"`
 	OriginScheme     string `envconfig:"ORIGIN_SCHEME" default:"http"`

--- a/pkg/proxy_test.go
+++ b/pkg/proxy_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNewReverseProxy(t *testing.T) {
-	proxy := NewReverseProxy("http", "example.com", 8080)
+	proxy := NewReverseProxy("http", "localhost", "example.com", 8080)
 	if proxy == nil {
 		t.Fatal("Expected non-nil proxy")
 	}


### PR DESCRIPTION
This pull request introduces changes to add support for a new `PROXY_DOMAIN` configuration in the reverse proxy. The most important changes include updating the configuration structure, modifying the reverse proxy initialization, and adjusting the proxy behavior based on the new domain.

Configuration updates:

* [`pkg/config.go`](diffhunk://#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cR11): Added a new `ProxyDomain` field to the `Config` struct with a default value of `localhost`.

Proxy initialization and behavior:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L22-R25): Updated the reverse proxy initialization to include the new `ProxyDomain` configuration.
* [`pkg/proxy.go`](diffhunk://#diff-cf1b566c0af592761aa04d0a619320a3e46149097301d959d71fd07dc6d08f2cL23-R35): Modified the `NewReverseProxy` function to accept the new `proxyDomain` parameter and added logic to handle requests based on the `proxyDomain`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23): Added a description for the new `PROXY_DOMAIN` environment variable.

Testing updates:

* [`pkg/proxy_test.go`](diffhunk://#diff-9b56847186ff76b1b50618ed24acf954046035b07eb44f793d0e628dc574a402L8-R8): Updated the `TestNewReverseProxy` test to include the `proxyDomain` parameter.