### PR TITLE
fix: correct host validation in reverse proxy logic

### DIFF
--- a/pkg/proxy.go
+++ b/pkg/proxy.go
@@ -26,7 +26,7 @@ func NewReverseProxy(schema string, proxyDomain string, baseDomain string, port 
 		if strings.Contains(host, ":") {
 			host = strings.Split(host, ":")[0]
 		}
-		if !strings.HasPrefix(host, proxyDomain) {
+		if !strings.HasSuffix(host, proxyDomain) {
 			slog.Warn("proxy warn", slog.Any("warn", host), slog.Any("proxyDomain", proxyDomain))
 			req.URL.Scheme = ""
 			req.URL.Host = ""


### PR DESCRIPTION
This pull request includes a modification to the `NewReverseProxy` function in the `pkg/proxy.go` file. The change updates the logic for checking the `proxyDomain` in the host string.

* [`pkg/proxy.go`](diffhunk://#diff-cf1b566c0af592761aa04d0a619320a3e46149097301d959d71fd07dc6d08f2cL29-R29): Modified the condition to check if the host string ends with the `proxyDomain` instead of starting with it.